### PR TITLE
making singlepage call to remote by default

### DIFF
--- a/percy/providers/app_automate.py
+++ b/percy/providers/app_automate.py
@@ -37,6 +37,8 @@ class AppAutomate(GenericProvider):
     def _get_tiles(self, **kwargs):
         fullpage_ss = kwargs.get('fullpage', False)
         if os.environ.get('PERCY_DISABLE_REMOTE_UPLOADS') == 'true':
+            if fullpage_ss:
+                log('Full page screenshots are only supported when "PERCY_DISABLE_REMOTE_UPLOADS" is not set')
             return super()._get_tiles(**kwargs)
         screenshotType = 'fullpage' if fullpage_ss else 'singlepage'
         screen_lengths = kwargs.get('screen_lengths', 4)

--- a/percy/providers/app_automate.py
+++ b/percy/providers/app_automate.py
@@ -38,9 +38,7 @@ class AppAutomate(GenericProvider):
         fullpage_ss = kwargs.get('fullpage', False)
         if os.environ.get('PERCY_DISABLE_REMOTE_UPLOADS') == 'true':
             return super()._get_tiles(**kwargs)
-        screenshotType = 'singlepage'
-        if fullpage_ss:
-            screenshotType = 'fullpage'
+        screenshotType = 'fullpage' if fullpage_ss else 'singlepage'
         screen_lengths = kwargs.get('screen_lengths', 4)
         scrollable_xpath = kwargs.get('scollable_xpath')
         scrollable_id = kwargs.get('scrollable_id')
@@ -113,9 +111,7 @@ class AppAutomate(GenericProvider):
         scale_factor=1
     ):
         try:
-            projectId = 'percy-prod'
-            if os.environ.get('PERCY_ENABLE_DEV') == 'true':
-                projectId = 'percy-dev'
+            projectId = 'percy-dev' if os.environ.get('PERCY_ENABLE_DEV') == 'true' else 'percy-prod'
             request_body = {
                 'action': 'percyScreenshot',
                 'arguments': {

--- a/percy/providers/app_automate.py
+++ b/percy/providers/app_automate.py
@@ -36,13 +36,17 @@ class AppAutomate(GenericProvider):
 
     def _get_tiles(self, **kwargs):
         fullpage_ss = kwargs.get('fullpage', False)
-        if not fullpage_ss:
+        if os.environ.get('PERCY_DISABLE_REMOTE_UPLOADS') == 'true':
             return super()._get_tiles(**kwargs)
+        screenshotType = 'singlepage'
+        if fullpage_ss:
+            screenshotType = 'fullpage'
         screen_lengths = kwargs.get('screen_lengths', 4)
         scrollable_xpath = kwargs.get('scollable_xpath')
         scrollable_id = kwargs.get('scrollable_id')
         data = self.execute_percy_screenshot(
             self.metadata.device_screen_size.get('height', 1),
+            screenshotType,
             screen_lengths,
             scrollable_xpath,
             scrollable_id,
@@ -102,18 +106,23 @@ class AppAutomate(GenericProvider):
     def execute_percy_screenshot(
         self,
         device_height,
+        screenshotType,
         screen_lengths,
         scrollable_xpath=None,
         scrollable_id=None,
         scale_factor=1
     ):
         try:
+            projectId = 'percy-prod'
+            if os.environ.get('PERCY_ENABLE_DEV') == 'true':
+                projectId = 'percy-dev'
             request_body = {
                 'action': 'percyScreenshot',
                 'arguments': {
                     'state': 'screenshot',
                     'percyBuildId':  Environment.percy_build_id,
-                    'screenshotType': 'fullpage',
+                    'screenshotType': screenshotType,
+                    'projectId': projectId,
                     'scaleFactor': scale_factor,
                     'options': { 
                         "numOfTiles": screen_lengths,

--- a/tests/test_app_automate.py
+++ b/tests/test_app_automate.py
@@ -56,7 +56,7 @@ class TestAppAutomate(unittest.TestCase):
 
     def test_app_automate_execute_percy_screenshot(self):
         self.mock_webdriver.execute_script.return_value = '{"result": "result"}'
-        self.app_automate.execute_percy_screenshot(1080, 5)
+        self.app_automate.execute_percy_screenshot(1080, 'singlepage', 5)
         self.mock_webdriver.execute_script.assert_called()
 
     @patch('percy.providers.app_automate.log')

--- a/tests/test_app_percy.py
+++ b/tests/test_app_percy.py
@@ -16,7 +16,6 @@ from percy.providers.generic_provider import GenericProvider
 from percy.metadata import AndroidMetadata
 from tests.mocks.mock_methods import android_capabilities, ios_capabilities
 
-@patch.dict(os.environ, {"PERCY_DISABLE_REMOTE_UPLOADS": "true"})
 class TestAppPercy(unittest.TestCase):
     comparison_response = {'link': 'https://snapshot_url', 'success': True}
 
@@ -48,6 +47,7 @@ class TestAppPercy(unittest.TestCase):
     }))
     @patch.object(AppAutomate, 'execute_percy_screenshot_end', MagicMock(return_value=None))
     @patch.object(Metadata, 'session_id', PropertyMock(return_value='unique_session_id'))
+    @patch.dict(os.environ, {"PERCY_DISABLE_REMOTE_UPLOADS": "true"})
     def test_android_on_app_automate(self):
         with patch('percy.metadata.AndroidMetadata.remote_url', new_callable=PropertyMock) as mock_remote_url:
             mock_remote_url.return_value = 'url-of-browserstack-cloud'
@@ -79,7 +79,22 @@ class TestAppPercy(unittest.TestCase):
         'sessionHash': 'def'
     }))
     @patch.object(AppAutomate, 'execute_percy_screenshot_end', MagicMock(return_value=None))
+    @patch.dict(os.environ, {"PERCY_DISABLE_REMOTE_UPLOADS": "true"})
     def test_ios_on_app_automate(self):
+        with patch('percy.metadata.IOSMetadata.remote_url', new_callable=PropertyMock) as mock_remote_url:
+            mock_remote_url.return_value = 'url-of-browserstack-cloud'
+            app_percy = AppPercy(self.mock_ios_webdriver)
+            app_percy.screenshot('screenshot 1')
+            self.assertTrue(isinstance(app_percy.metadata, IOSMetadata))
+            self.assertTrue(isinstance(app_percy.provider, AppAutomate))
+
+    @patch.object(AppAutomate, 'execute_percy_screenshot_end', MagicMock(return_value=None))
+    @patch.object(AppAutomate, 'execute_percy_screenshot', MagicMock(return_value={
+        "result":"[{\"sha\":\"sha-25568755\",\"status_bar\":null,\"nav_bar\":null,\"header_height\":120,\"footer_height\":80,\"index\":0}]"
+    }))
+    @patch.object(CLIWrapper, 'post_screenshots', MagicMock(return_value=comparison_response))
+    @patch.object(Metadata, 'session_id', PropertyMock(return_value='unique_session_id'))
+    def test_ios_on_app_automate_with_remote_upload(self):
         with patch('percy.metadata.IOSMetadata.remote_url', new_callable=PropertyMock) as mock_remote_url:
             mock_remote_url.return_value = 'url-of-browserstack-cloud'
             app_percy = AppPercy(self.mock_ios_webdriver)

--- a/tests/test_app_percy.py
+++ b/tests/test_app_percy.py
@@ -1,6 +1,7 @@
 # pylint: disable=[arguments-differ, protected-access]
 import copy
 import unittest
+import os
 from unittest.mock import patch, Mock, MagicMock, PropertyMock
 
 from appium.webdriver.webdriver import WebDriver
@@ -15,7 +16,7 @@ from percy.providers.generic_provider import GenericProvider
 from percy.metadata import AndroidMetadata
 from tests.mocks.mock_methods import android_capabilities, ios_capabilities
 
-
+@patch.dict(os.environ, {"PERCY_DISABLE_REMOTE_UPLOADS": "true"})
 class TestAppPercy(unittest.TestCase):
     comparison_response = {'link': 'https://snapshot_url', 'success': True}
 


### PR DESCRIPTION
Taking singlepage ss for app automate from mobile.
Adding `PERCY_DISABLE_REMOTE_UPLOADS` env variable to override above.
Adding `PERCY_ENABLE_DEV` for dev. Added it so we can test better with sdk.

