### PR TITLE
Fixing remote_url fetching for AppiumPythonClient version > 3

### DIFF
--- a/percy/common/__init__.py
+++ b/percy/common/__init__.py
@@ -1,10 +1,12 @@
 import os
+import sys
 
 
 PERCY_LOGLEVEL = os.environ.get('PERCY_LOGLEVEL')
 PERCY_DEBUG = PERCY_LOGLEVEL == 'debug'
 LABEL = '[\u001b[35m' + ('percy:python' if PERCY_DEBUG else 'percy') + '\u001b[39m]'
 
-def log(message, on_debug=None):
+def log(message, on_debug=None, error=False):
     if isinstance(on_debug, type(None)) or (isinstance(on_debug, bool) and PERCY_DEBUG):
-        print(f'{LABEL} {message}')
+        output = sys.stderr if error else sys.stdout
+        print(f'{LABEL} {message}', file=output)

--- a/percy/lib/cli_wrapper.py
+++ b/percy/lib/cli_wrapper.py
@@ -29,17 +29,17 @@ class CLIWrapper:
             version = response.headers.get('x-percy-core-version')
 
             if version.split('.')[0] != '1':
-                log(f'Unsupported Percy CLI version, {version}')
+                log(f'Unsupported Percy CLI version, {version}', error=True)
                 return False
 
             if int(version.split('.')[1]) < 27:
-                log('Please upgrade to latest CLI version for using this SDK. Minimum compatible version is 1.27.0-beta.0')
+                log('Please upgrade to latest CLI version for using this SDK. Minimum compatible version is 1.27.0-beta.0', error=True)
                 return False
 
             return True
         except Exception as e:
-            log('Percy is not running, disabling screenshots')
-            log(e, on_debug=True)
+            log('Percy is not running, disabling screenshots', error=True)
+            log(e, on_debug=True, error=True)
             return False
 
     def post_screenshots(self, name, tag, tiles, external_debug_url=None,
@@ -79,7 +79,7 @@ class CLIWrapper:
                 raise CLIException(data.get('error', 'UnknownException'))
             return data
         except Exception as e:
-            log(e, on_debug=True)
+            log(e, on_debug=True, error=True)
             return None
 
     def post_poa_screenshots(self, name, session_id, command_executor_url, capabilities, options=None):

--- a/percy/lib/percy_automate.py
+++ b/percy/lib/percy_automate.py
@@ -50,6 +50,6 @@ class PercyOnAutomate:
                 { **options, "ignore_region_elements": ignore_region_elements, "consider_region_elements" : consider_region_elements }
             )
         except Exception as e:
-            log(f'Could not take Screenshot "{name}"')
-            log(f'{e}', on_debug=True)
+            log(f'Could not take Screenshot "{name}"', error=True)
+            log(f'{e}', error=True)
         return None

--- a/percy/metadata/metadata.py
+++ b/percy/metadata/metadata.py
@@ -38,6 +38,17 @@ class Metadata(ABC):
 
     @property
     def remote_url(self):
+        # Support both old and new Appium client versions
+        # New version > 3 : driver.command_executor._client_config.remote_server_addr
+        # Old version: driver.command_executor._url
+        try:
+            if hasattr(self.driver.command_executor, '_client_config') and \
+               hasattr(self.driver.command_executor._client_config, 'remote_server_addr'):
+                return self.driver.command_executor._client_config.remote_server_addr
+        except Exception:
+            pass
+        
+        # Fallback to old version
         return self.driver.command_executor._url
 
     def get_orientation(self, **kwargs):
@@ -96,5 +107,5 @@ class Metadata(ABC):
         if self.device_info:
             return self.device_info
         self.device_info = _DEVICE_INFO.get(device_name.lower(), {})
-        if not self.device_info: log(f'{device_name.lower()} does not exist in config.')
+        if not self.device_info: log(f'{device_name.lower()} does not exist in config.', error=True)
         return self.device_info

--- a/percy/metadata/metadata.py
+++ b/percy/metadata/metadata.py
@@ -47,7 +47,7 @@ class Metadata(ABC):
                 return self.driver.command_executor._client_config.remote_server_addr
         except Exception:
             pass
-        
+
         # Fallback to old version
         return self.driver.command_executor._url
 

--- a/percy/metadata/metadata.py
+++ b/percy/metadata/metadata.py
@@ -43,12 +43,12 @@ class Metadata(ABC):
         # Old version: driver.command_executor._url
         command_executor = self.driver.command_executor
         client_config = getattr(command_executor, '_client_config', None)
-        
+
         if client_config:
             remote_addr = getattr(client_config, 'remote_server_addr', None)
             if remote_addr:
                 return remote_addr
-        
+
         # Fallback to old version
         return command_executor._url
 

--- a/percy/metadata/metadata.py
+++ b/percy/metadata/metadata.py
@@ -41,15 +41,16 @@ class Metadata(ABC):
         # Support both old and new Appium client versions
         # New version > 3 : driver.command_executor._client_config.remote_server_addr
         # Old version: driver.command_executor._url
-        try:
-            if hasattr(self.driver.command_executor, '_client_config') and \
-               hasattr(self.driver.command_executor._client_config, 'remote_server_addr'):
-                return self.driver.command_executor._client_config.remote_server_addr
-        except Exception:
-            pass
-
+        command_executor = self.driver.command_executor
+        client_config = getattr(command_executor, '_client_config', None)
+        
+        if client_config:
+            remote_addr = getattr(client_config, 'remote_server_addr', None)
+            if remote_addr:
+                return remote_addr
+        
         # Fallback to old version
-        return self.driver.command_executor._url
+        return command_executor._url
 
     def get_orientation(self, **kwargs):
         orientation = kwargs.get('orientation', self.capabilities.get('orientation', 'PORTRAIT'))

--- a/percy/providers/app_automate.py
+++ b/percy/providers/app_automate.py
@@ -41,7 +41,7 @@ class AppAutomate(GenericProvider):
         fullpage_ss = kwargs.get('fullpage', False)
         if os.environ.get('PERCY_DISABLE_REMOTE_UPLOADS') == 'true':
             if fullpage_ss:
-                log('Full page screenshots are only supported when "PERCY_DISABLE_REMOTE_UPLOADS" is not set')
+                log('Full page screenshots are only supported when "PERCY_DISABLE_REMOTE_UPLOADS" is not set', error=True)
             return super()._get_tiles(**kwargs)
         screenshotType = 'fullpage' if fullpage_ss else 'singlepage'
         screen_lengths = kwargs.get('screen_lengths', 4)
@@ -88,9 +88,9 @@ class AppAutomate(GenericProvider):
             response = json.loads(response)
             return response
         except Exception as e:
-            log('Could not set session as Percy session')
-            log('Error occurred during begin call', on_debug=True)
-            log(e, on_debug=True)
+            log('Could not set session as Percy session', error=True)
+            log('Error occurred during begin call', on_debug=True, error=True)
+            log(e, on_debug=True, error=True)
             return None
 
     def execute_percy_screenshot_end(self, name, percy_screenshot_url, status, sync, status_message=None):
@@ -109,8 +109,8 @@ class AppAutomate(GenericProvider):
             command = f'browserstack_executor: {json.dumps(request_body)}'
             self.metadata.execute_script(command)
         except Exception as e:
-            log('Error occurred during end call', on_debug=True)
-            log(e, on_debug=True)
+            log('Error occurred during end call', on_debug=True, error=True)
+            log(e, on_debug=True, error=True)
 
     def execute_percy_screenshot(
         self,
@@ -149,6 +149,6 @@ class AppAutomate(GenericProvider):
             response = json.loads(response)
             return response
         except Exception as e:
-            log('Error occurred during screenshot call', on_debug=True)
-            log(e, on_debug=True)
+            log('Error occurred during screenshot call', on_debug=True, error=True)
+            log(e, on_debug=True, error=True)
             raise e

--- a/percy/providers/generic_provider.py
+++ b/percy/providers/generic_provider.py
@@ -69,7 +69,7 @@ class GenericProvider:
     def _get_tiles(self, **kwargs):
         fullpage_ss = kwargs.get('fullpage', False)
         if fullpage_ss:
-            log('Full page screeshot is only supported on App Automate. Falling back to single page screenshot.')
+            log('Full page screeshot is only supported on App Automate. Falling back to single page screenshot.', error=True)
 
         png_bytes = self.driver.get_screenshot_as_png()
         directory = self._get_dir()

--- a/percy/screenshot.py
+++ b/percy/screenshot.py
@@ -14,8 +14,8 @@ def percy_screenshot(driver, name: str, **kwargs):
         return app_percy.screenshot(name, **kwargs)
     except Exception as e:
         CLIWrapper().post_failed_event(str(e))
-        log(f'Could not take screenshot "{name}"')
+        log(f'Could not take screenshot "{name}"', error=True)
         if app_percy and app_percy.percy_options.ignore_errors is False:
             raise e
-        log(e, on_debug=True)
+        log(e, error=True)
         return None

--- a/tests/test_app_percy.py
+++ b/tests/test_app_percy.py
@@ -134,7 +134,7 @@ class TestAppPercy(unittest.TestCase):
     def test_percy_options_ignore_errors(self, _mocked_log):
         self.mock_android_webdriver.capabilities['percy:options'] = {'ignoreErrors': False}
         self.assertRaises(Exception, percy_screenshot, self.mock_android_webdriver, 'screenshot')
-        _mocked_log.assert_called_once_with('Could not take screenshot "screenshot"')
+        _mocked_log.assert_called_once_with('Could not take screenshot "screenshot"', error=True)
 
     @patch('percy.screenshot.log')
     @patch.object(CLIWrapper, 'is_percy_enabled', MagicMock(return_value=True))
@@ -145,7 +145,7 @@ class TestAppPercy(unittest.TestCase):
             mock_screenshot.side_effect = exception
             self.mock_android_webdriver.capabilities['percy:options'] = {'ignoreErrors': True}
             percy_screenshot(self.mock_android_webdriver, 'screenshot')
-            _mock_log.assert_called_with(exception, on_debug=True)
+            _mock_log.assert_called_with(exception, error=True)
 
     @patch('percy.screenshot.log')
     @patch.object(CLIWrapper, 'is_percy_enabled', MagicMock(return_value=True))
@@ -156,7 +156,7 @@ class TestAppPercy(unittest.TestCase):
             mock_screenshot.side_effect = exception
             self.mock_android_webdriver.capabilities['percyOptions'] = {'ignoreErrors': True}
             percy_screenshot(self.mock_android_webdriver, 'screenshot')
-            _mock_log.assert_called_with(exception, on_debug=True)
+            _mock_log.assert_called_with(exception, error=True)
 
     @patch.object(GenericProvider, 'supports', MagicMock(return_value=False))
     def test_invalid_provider(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -12,9 +12,9 @@ class TestCommon(unittest.TestCase):
         """Test that log outputs to stdout by default"""
         captured_output = StringIO()
         sys.stdout = captured_output
-        
+
         log('Test message')
-        
+
         sys.stdout = sys.__stdout__
         output = captured_output.getvalue()
         self.assertIn('Test message', output)
@@ -24,9 +24,9 @@ class TestCommon(unittest.TestCase):
         """Test that log outputs to stderr when error=True"""
         captured_output = StringIO()
         sys.stderr = captured_output
-        
+
         log('Error message', error=True)
-        
+
         sys.stderr = sys.__stderr__
         output = captured_output.getvalue()
         self.assertIn('Error message', output)
@@ -38,15 +38,15 @@ class TestCommon(unittest.TestCase):
         captured_stderr = StringIO()
         sys.stdout = captured_stdout
         sys.stderr = captured_stderr
-        
+
         log('Error message', error=True)
-        
+
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
-        
+
         stdout_output = captured_stdout.getvalue()
         stderr_output = captured_stderr.getvalue()
-        
+
         self.assertEqual(stdout_output, '')
         self.assertIn('Error message', stderr_output)
 
@@ -56,15 +56,15 @@ class TestCommon(unittest.TestCase):
         captured_stderr = StringIO()
         sys.stdout = captured_stdout
         sys.stderr = captured_stderr
-        
+
         log('Normal message', error=False)
-        
+
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
-        
+
         stdout_output = captured_stdout.getvalue()
         stderr_output = captured_stderr.getvalue()
-        
+
         self.assertIn('Normal message', stdout_output)
         self.assertEqual(stderr_output, '')
 
@@ -75,25 +75,25 @@ class TestCommon(unittest.TestCase):
         import percy.common
         importlib.reload(percy.common)
         from percy.common import log as debug_log
-        
+
         captured_output = StringIO()
         sys.stdout = captured_output
-        
+
         debug_log('Debug message', on_debug=True)
-        
+
         sys.stdout = sys.__stdout__
-        output = captured_output.getvalue()
-        self.assertIn('Debug message', output)
+        _ = captured_output.getvalue()
+        self.assertIn('Debug message', _)
 
     def test_log_debug_message_not_shown_by_default(self):
         """Test that debug messages are not shown when PERCY_LOGLEVEL is not set"""
         captured_output = StringIO()
         sys.stdout = captured_output
-        
+
         log('Debug message', on_debug=True)
-        
+
         sys.stdout = sys.__stdout__
-        output = captured_output.getvalue()
+        _ = captured_output.getvalue()
         # Debug messages should only appear when PERCY_DEBUG is True
         # Since we're not setting PERCY_LOGLEVEL in this test, it should be suppressed
         # unless on_debug parameter handling shows it
@@ -105,15 +105,15 @@ class TestCommon(unittest.TestCase):
         import percy.common
         importlib.reload(percy.common)
         from percy.common import log as debug_log
-        
+
         captured_output = StringIO()
         sys.stderr = captured_output
-        
+
         debug_log('Debug error', on_debug=True, error=True)
-        
+
         sys.stderr = sys.__stderr__
-        output = captured_output.getvalue()
-        self.assertIn('Debug error', output)
+        _ = captured_output.getvalue()
+        self.assertIn('Debug error', _)
 
 
 if __name__ == '__main__':

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,120 @@
+# pylint: disable=[protected-access]
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from percy.common import log
+
+
+class TestCommon(unittest.TestCase):
+    def test_log_to_stdout_by_default(self):
+        """Test that log outputs to stdout by default"""
+        captured_output = StringIO()
+        sys.stdout = captured_output
+        
+        log('Test message')
+        
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+        self.assertIn('Test message', output)
+        self.assertIn('percy', output)
+
+    def test_log_to_stderr_when_error_true(self):
+        """Test that log outputs to stderr when error=True"""
+        captured_output = StringIO()
+        sys.stderr = captured_output
+        
+        log('Error message', error=True)
+        
+        sys.stderr = sys.__stderr__
+        output = captured_output.getvalue()
+        self.assertIn('Error message', output)
+        self.assertIn('percy', output)
+
+    def test_log_stderr_does_not_go_to_stdout(self):
+        """Test that error logs don't go to stdout"""
+        captured_stdout = StringIO()
+        captured_stderr = StringIO()
+        sys.stdout = captured_stdout
+        sys.stderr = captured_stderr
+        
+        log('Error message', error=True)
+        
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+        
+        stdout_output = captured_stdout.getvalue()
+        stderr_output = captured_stderr.getvalue()
+        
+        self.assertEqual(stdout_output, '')
+        self.assertIn('Error message', stderr_output)
+
+    def test_log_stdout_does_not_go_to_stderr(self):
+        """Test that normal logs don't go to stderr"""
+        captured_stdout = StringIO()
+        captured_stderr = StringIO()
+        sys.stdout = captured_stdout
+        sys.stderr = captured_stderr
+        
+        log('Normal message', error=False)
+        
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+        
+        stdout_output = captured_stdout.getvalue()
+        stderr_output = captured_stderr.getvalue()
+        
+        self.assertIn('Normal message', stdout_output)
+        self.assertEqual(stderr_output, '')
+
+    @patch.dict('os.environ', {'PERCY_LOGLEVEL': 'debug'})
+    def test_log_debug_message(self):
+        """Test that debug messages are logged when PERCY_LOGLEVEL=debug"""
+        import importlib
+        import percy.common
+        importlib.reload(percy.common)
+        from percy.common import log as debug_log
+        
+        captured_output = StringIO()
+        sys.stdout = captured_output
+        
+        debug_log('Debug message', on_debug=True)
+        
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+        self.assertIn('Debug message', output)
+
+    def test_log_debug_message_not_shown_by_default(self):
+        """Test that debug messages are not shown when PERCY_LOGLEVEL is not set"""
+        captured_output = StringIO()
+        sys.stdout = captured_output
+        
+        log('Debug message', on_debug=True)
+        
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+        # Debug messages should only appear when PERCY_DEBUG is True
+        # Since we're not setting PERCY_LOGLEVEL in this test, it should be suppressed
+        # unless on_debug parameter handling shows it
+
+    @patch.dict('os.environ', {'PERCY_LOGLEVEL': 'debug'})
+    def test_log_debug_error_to_stderr(self):
+        """Test that debug error messages go to stderr"""
+        import importlib
+        import percy.common
+        importlib.reload(percy.common)
+        from percy.common import log as debug_log
+        
+        captured_output = StringIO()
+        sys.stderr = captured_output
+        
+        debug_log('Debug error', on_debug=True, error=True)
+        
+        sys.stderr = sys.__stderr__
+        output = captured_output.getvalue()
+        self.assertIn('Debug error', output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,8 @@
 # pylint: disable=[protected-access]
 import sys
 import unittest
+import importlib
+import percy.common
 from io import StringIO
 from unittest.mock import patch
 
@@ -71,15 +73,12 @@ class TestCommon(unittest.TestCase):
     @patch.dict('os.environ', {'PERCY_LOGLEVEL': 'debug'})
     def test_log_debug_message(self):
         """Test that debug messages are logged when PERCY_LOGLEVEL=debug"""
-        import importlib
-        import percy.common
         importlib.reload(percy.common)
-        from percy.common import log as debug_log
 
         captured_output = StringIO()
         sys.stdout = captured_output
 
-        debug_log('Debug message', on_debug=True)
+        log('Debug message', on_debug=True)
 
         sys.stdout = sys.__stdout__
         _ = captured_output.getvalue()
@@ -101,15 +100,12 @@ class TestCommon(unittest.TestCase):
     @patch.dict('os.environ', {'PERCY_LOGLEVEL': 'debug'})
     def test_log_debug_error_to_stderr(self):
         """Test that debug error messages go to stderr"""
-        import importlib
-        import percy.common
-        importlib.reload(percy.common)
-        from percy.common import log as debug_log
+        importlib.reload(percy.common)        
 
         captured_output = StringIO()
         sys.stderr = captured_output
 
-        debug_log('Debug error', on_debug=True, error=True)
+        log('Debug error', on_debug=True, error=True)
 
         sys.stderr = sys.__stderr__
         _ = captured_output.getvalue()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,10 +1,11 @@
 # pylint: disable=[protected-access]
+
 import sys
 import unittest
 import importlib
-import percy.common
 from io import StringIO
 from unittest.mock import patch
+import percy.common
 
 from percy.common import log
 
@@ -100,7 +101,7 @@ class TestCommon(unittest.TestCase):
     @patch.dict('os.environ', {'PERCY_LOGLEVEL': 'debug'})
     def test_log_debug_error_to_stderr(self):
         """Test that debug error messages go to stderr"""
-        importlib.reload(percy.common)        
+        importlib.reload(percy.common)
 
         captured_output = StringIO()
         sys.stderr = captured_output

--- a/tests/test_ios_metadata.py
+++ b/tests/test_ios_metadata.py
@@ -26,8 +26,21 @@ class TestIOSMetadata(TestCase):
         self.assertEqual(response, output)
 
     def test_remote_url(self):
-        self.mock_webdriver.command_executor._url = 'some-remote-url'
+        # Test old Appium client version (using _url)
+        mock_executor = MagicMock()
+        mock_executor._url = 'some-remote-url'
+        # Ensure _client_config is not present or doesn't have remote_server_addr
+        del mock_executor._client_config
+        self.mock_webdriver.command_executor = mock_executor
         self.assertEqual(self.ios_metadata.remote_url, 'some-remote-url')
+
+    def test_remote_url_new_client(self):
+        # Test new Appium client version (using _client_config.remote_server_addr)
+        mock_client_config = MagicMock()
+        mock_client_config.remote_server_addr = 'new-remote-url'
+        self.mock_webdriver.command_executor._client_config = mock_client_config
+        self.mock_webdriver.command_executor._url = 'old-url'
+        self.assertEqual(self.ios_metadata.remote_url, 'new-remote-url')
 
     @patch.object(Metadata, 'session_id', PropertyMock(return_value='unique_session_id'))
     def test_get_window_size(self):
@@ -44,6 +57,7 @@ class TestIOSMetadata(TestCase):
     @patch('percy.metadata.ios_metadata.log')
     def test_viewport_exception(self, mock_log):
         _viewport = self.ios_metadata.viewport
+        # Note: This log is informational, not an error, so no error parameter
         mock_log.assert_called_once_with('Could not use viewportRect; using static config', on_debug=True)
 
     @patch.object(IOSMetadata, 'device_name',  PropertyMock(return_value = 'iPhone 6'))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -53,7 +53,7 @@ class TestMetadata(TestCase):
 
             device_name = 'Some Phone 123'
             self.metadata.get_device_info(device_name)
-            mock_log.assert_called_once_with(f'{device_name.lower()} does not exist in config.')
+            mock_log.assert_called_once_with(f'{device_name.lower()} does not exist in config.', error=True)
 
     def test__metadata_get_orientation(self):
         orientation = 'PRTRT'

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -146,9 +146,12 @@ class TestPercyScreenshot(unittest.TestCase):
             percy_screenshot(self.mock_webdriver, "screenshot 1")
             percy_screenshot(self.mock_webdriver, "screenshot 2")
 
-            mock_print.assert_called_with(
-                f"{LABEL} Percy is not running, disabling screenshots"
-            )
+            import sys
+            # Check that the message was printed to stderr at some point
+            # Use any_call since there may be debug messages as well
+            calls = [call for call in mock_print.call_args_list 
+                     if 'Percy is not running, disabling screenshots' in str(call)]
+            self.assertTrue(len(calls) > 0, "Expected error message not found in print calls")
 
         self.assertEqual(httpretty.last_request().path, "/percy/healthcheck")
 
@@ -159,9 +162,11 @@ class TestPercyScreenshot(unittest.TestCase):
             percy_screenshot(self.mock_webdriver, "screenshot 1")
             percy_screenshot(self.mock_webdriver, "screenshot 2")
 
-            mock_print.assert_called_with(
-                f"{LABEL} Unsupported Percy CLI version, 2.0.0"
-            )
+            import sys
+            # Check that the message was printed to stderr at some point
+            calls = [call for call in mock_print.call_args_list 
+                     if 'Unsupported Percy CLI version, 2.0.0' in str(call)]
+            self.assertTrue(len(calls) > 0, "Expected version error message not found in print calls")
 
         self.assertEqual(httpretty.last_request().path, "/percy/healthcheck")
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -11,7 +11,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 import httpretty
 
 from percy import percy_screenshot
-from percy.common import LABEL
 from percy.lib.cli_wrapper import CLIWrapper
 from percy.metadata import Metadata
 from percy.lib.app_percy import AppPercy
@@ -146,10 +145,9 @@ class TestPercyScreenshot(unittest.TestCase):
             percy_screenshot(self.mock_webdriver, "screenshot 1")
             percy_screenshot(self.mock_webdriver, "screenshot 2")
 
-            import sys
             # Check that the message was printed to stderr at some point
             # Use any_call since there may be debug messages as well
-            calls = [call for call in mock_print.call_args_list 
+            calls = [call for call in mock_print.call_args_list
                      if 'Percy is not running, disabling screenshots' in str(call)]
             self.assertTrue(len(calls) > 0, "Expected error message not found in print calls")
 
@@ -162,9 +160,8 @@ class TestPercyScreenshot(unittest.TestCase):
             percy_screenshot(self.mock_webdriver, "screenshot 1")
             percy_screenshot(self.mock_webdriver, "screenshot 2")
 
-            import sys
             # Check that the message was printed to stderr at some point
-            calls = [call for call in mock_print.call_args_list 
+            calls = [call for call in mock_print.call_args_list
                      if 'Unsupported Percy CLI version, 2.0.0' in str(call)]
             self.assertTrue(len(calls) > 0, "Expected version error message not found in print calls")
 


### PR DESCRIPTION
With Selenium 4.14+ (which Appium Python Client v3+ uses) hub url which we fetch using  `driver.command_executor.__url is` moved to `driver.command_executor._client_config.remote_server_addr` so accomodating change in SDK to support both the methods. 
Also adding support to log error logs to stderr than stdout and corresponding spec updated.