### PR TITLE
🔖 Release - v2.0.8-beta.1

### DIFF
--- a/percy/version.py
+++ b/percy/version.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.8-beta.0'
+__version__ = '2.0.8-beta.1'


### PR DESCRIPTION
Version bump to **2.0.8-beta.1** for the Appium version-compatibility work (PER-7786, #211 — Selenium 4.x command-executor URL).

- `percy/version.py`: 2.0.8-beta.0 → 2.0.8-beta.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)